### PR TITLE
feat: separate http api and mqtt

### DIFF
--- a/iot-backend/README.md
+++ b/iot-backend/README.md
@@ -1,8 +1,21 @@
+Local development
+
+- API server (port 3001 by default):
+
 ```
 npm install
 npm run dev
 ```
 
+- MQTT worker (persistent subscriber, stores sensor data and relay logs):
+
 ```
-open http://localhost:3000
+npm run build:worker
+npm run start:worker
 ```
+
+Notes
+
+- On serverless platforms (e.g., Vercel), the API will not start MQTT listeners automatically.
+- Deploy the worker to a persistent host (Railway/Render/Fly/VPS) and set the same environment variables (.env).
+- The API publish endpoint is serverless-safe (connect→publish→disconnect per request).

--- a/iot-backend/package.json
+++ b/iot-backend/package.json
@@ -5,11 +5,14 @@
     "dev": "tsx watch src/index.ts",
     "build": "tsc",
     "start": "prisma generate && node dist/index.js",
+    "start:worker": "node dist/mqtt-worker.js",
+    "dev:worker": "tsx watch src/mqtt-worker.ts",
     "postinstall": "prisma generate"
   },
   "dependencies": {
     "@hono/node-server": "^1.19.0",
     "@prisma/client": "^6.14.0",
+    "dotenv": "^16.4.5",
     "hono": "^4.9.4",
     "mqtt": "^5.14.0",
     "prisma": "^6.14.0",

--- a/iot-backend/src/index.ts
+++ b/iot-backend/src/index.ts
@@ -14,7 +14,11 @@ app.use('*', logger());
 app.use(
   '*',
   cors({
-    origin: ['https://smart-farming-dashboard-eosin.vercel.app','http://localhost:3000', 'http://localhost:3001',], // need to be change into real url if already acc
+    origin: [
+      'https://smart-farming-dashboard-eosin.vercel.app',
+      'http://localhost:3000',
+      'http://localhost:3001',
+    ], // need to be change into real url if already acc
     allowMethods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
     allowHeaders: ['Content-Type', 'Authorization', 'X-ESP32-Device'],
   }),
@@ -89,10 +93,14 @@ serve(
     console.log(
       `🔍 Health check at http://localhost:${info.port}/api/health`,
     );
-    // Start MQTT subscriptions (non-blocking)
-    startMqttListeners().catch((e) =>
-      console.error('Failed to start MQTT listeners:', e),
-    );
+    // Start MQTT subscriptions only on persistent runtimes
+    if (!process.env.VERCEL && process.env.ENABLE_MQTT !== '0') {
+      startMqttListeners().catch((e) =>
+        console.error('Failed to start MQTT listeners:', e),
+      );
+    } else {
+      console.log('⚠️ Skipping MQTT listeners in serverless runtime');
+    }
   },
 );
 

--- a/iot-backend/src/mqtt-worker.ts
+++ b/iot-backend/src/mqtt-worker.ts
@@ -1,0 +1,39 @@
+import 'dotenv/config';
+import { startMqttListeners } from './services/mqtt.listener.js';
+import { disconnectMqtt } from './services/mqtt.service.js';
+import { disconnectDatabase } from './database/connection.js';
+
+async function main() {
+  console.log('🚀 Starting MQTT worker...');
+  try {
+    await startMqttListeners();
+    console.log('📡 MQTT worker running (subscribed)');
+  } catch (e) {
+    console.error('❌ MQTT worker failed to start:', e);
+    process.exit(1);
+  }
+
+  // Keep process alive
+  process.stdin.resume();
+}
+
+main();
+
+// Graceful shutdown
+async function shutdown(signal: string) {
+  console.log(`\n📴 [worker] Received ${signal}. Shutting down...`);
+  try {
+    await disconnectMqtt();
+  } catch (e) {
+    console.error('Error disconnecting MQTT in worker:', e);
+  }
+  try {
+    await disconnectDatabase();
+  } catch (e) {
+    console.error('Error disconnecting DB in worker:', e);
+  }
+  process.exit(0);
+}
+
+process.on('SIGINT', () => shutdown('SIGINT'));
+process.on('SIGTERM', () => shutdown('SIGTERM'));

--- a/iot-backend/src/services/mqtt.listener.ts
+++ b/iot-backend/src/services/mqtt.listener.ts
@@ -42,6 +42,7 @@ const handleSensorMessage = async (
   topic: string,
   payload: Buffer,
 ) => {
+  console.log('payload:', payload);
   const json = tryParseJSON(payload);
   if (!json || typeof json !== 'object') {
     console.warn(
@@ -190,6 +191,7 @@ export const startMqttListeners = async () => {
 
   // Attach message handler once
   const onMessage = async (topic: string, payload: Buffer) => {
+    console.log({ topic, payload });
     try {
       if (isSensorTopic(topic)) {
         await handleSensorMessage(topic, payload);

--- a/iot-backend/src/services/mqtt.listener.ts
+++ b/iot-backend/src/services/mqtt.listener.ts
@@ -42,7 +42,6 @@ const handleSensorMessage = async (
   topic: string,
   payload: Buffer,
 ) => {
-  console.log('payload:', payload);
   const json = tryParseJSON(payload);
   if (!json || typeof json !== 'object') {
     console.warn(
@@ -191,7 +190,6 @@ export const startMqttListeners = async () => {
 
   // Attach message handler once
   const onMessage = async (topic: string, payload: Buffer) => {
-    console.log({ topic, payload });
     try {
       if (isSensorTopic(topic)) {
         await handleSensorMessage(topic, payload);


### PR DESCRIPTION
This pull request introduces improvements for running the IoT backend in both serverless and persistent environments. The main changes include adding a dedicated MQTT worker for persistent subscriptions, updating documentation and scripts for local development, and refactoring MQTT connection logic to support serverless-safe publishing. These updates make it easier to deploy and run the backend flexibly across different platforms.

**MQTT Worker & Local Development**

* Added a new `mqtt-worker` entry point (`src/mqtt-worker.ts`) for persistent MQTT subscriptions, including graceful shutdown handling.
* Updated `README.md` with clear instructions for running the API server and MQTT worker separately, and deployment notes for serverless platforms.
* Updated `package.json` scripts to support building and running the MQTT worker in both development and production modes.

**Serverless Compatibility & MQTT Logic**

* Refactored MQTT connection logic in `mqtt.service.ts` to support one-shot connections for serverless publish requests, ensuring connections are opened and closed per request.
* Added environment variable assertions in `mqtt.service.ts` to prevent misconfiguration and improve error reporting. [[1]](diffhunk://#diff-e9a1d87676798b99a5d4fb0ada65677048ba9e5dde08082c325b7746b8c77477R15-R30) [[2]](diffhunk://#diff-e9a1d87676798b99a5d4fb0ada65677048ba9e5dde08082c325b7746b8c77477R48)
* Changed API server startup to only run persistent MQTT listeners on non-serverless runtimes, with clear logging.

**General Improvements**

* Minor formatting and clarification of allowed CORS origins in `src/index.ts`.