### PR TITLE
Feat: add modem relay to activate the mifi at the beginning start up

### DIFF
--- a/iot-devices/include/actuators/ModemRelay.h
+++ b/iot-devices/include/actuators/ModemRelay.h
@@ -1,0 +1,19 @@
+#ifndef MODEM_RELAY_H
+#define MODEM_RELAY_H
+
+#include <Arduino.h>
+
+class ModemRelay {
+private:
+    int pin;
+    bool isActive;
+
+public:
+    ModemRelay(int relayPin);
+    void begin();
+    void turnOn();
+    void turnOff();
+    bool isRelayActive() const;
+};
+
+#endif

--- a/iot-devices/include/actuators/RelayController.h
+++ b/iot-devices/include/actuators/RelayController.h
@@ -8,7 +8,7 @@ private:
     int pin;
     bool isActive;
     bool lastState;
-    const int SOIL_THRESHOLD = 20;       // 0-20% soil moisture triggers pump
+    const int SOIL_THRESHOLD = 10;       // 0-10% soil moisture triggers pump
 
 public:
     RelayController(int relayPin);

--- a/iot-devices/include/display/OLEDDisplay.h
+++ b/iot-devices/include/display/OLEDDisplay.h
@@ -20,7 +20,7 @@ public:
     ~OLEDDisplay(); // Add destructor
     bool begin();
     void showStartupMessage();
-    void updateSensorData(float temp, float humidity, int soilMoisture, 
+    void updateSensorData(float temp, float humidity, int soilMoisture, float soilTemp,
                          String waterLevel, bool rain, bool pumpActive, bool wifiConnected);
     void clearDisplay();
     void displayError(const String& errorMessage);

--- a/iot-devices/include/utils/SensorCalibration.h
+++ b/iot-devices/include/utils/SensorCalibration.h
@@ -16,23 +16,19 @@ namespace Pins {
     const int SCL_PIN = 22;            // SCL pin for OLED
 }
 
-// DHT11 Configuration
 namespace DHT11Config {
     const int DHT_TYPE = 11;           // DHT11 sensor type
 }
 
-// DS18B20 Soil Temperature Configuration
 namespace DS18B20Config {
     const int RESOLUTION_BITS = 12;    // 12-bit resolution (0.0625°C precision)
     const unsigned long CONVERSION_TIME = 750; // 750ms for 12-bit conversion
 }
 
-// Soil Moisture Sensor Calibration
 namespace SoilMoistureCalibration {
     extern const int DRY_VALUE;    // 0% moisture (completely dry)
     extern const int WET_VALUE;    // 100% moisture (completely wet)
     
-    // Convert raw soil moisture value to percentage
     int convertToPercentage(int rawValue);
 }
 
@@ -42,26 +38,22 @@ namespace WaterLevelCalibration {
     const int WET_VALUE = 1050;       // Sensor value when sensor is fully submerged
     const int SENSOR_HEIGHT_CM = 5;   // Actual height of your sensor in cm
     
-    extern const int LOW_THRESHOLD;     // Below this = Low
-    extern const int MEDIUM_THRESHOLD;  // Below this = Medium, above = High
+    extern const int LOW_THRESHOLD;     
+    extern const int MEDIUM_THRESHOLD;  
     
-    // Determine water level status based on raw value
     String determineStatus(int rawValue);
 }
 
-// Relay Control Thresholds
 namespace RelayThresholds {
     const int SOIL_MOISTURE_THRESHOLD = 10;   // 0-10% soil moisture triggers pump
     
 }
 
-// Timing Configuration
 namespace Timing {
-    const unsigned long SENSOR_INTERVAL = 2000;  // Read sensor every 2 seconds
-    const unsigned long SEND_INTERVAL = 300000;  // Send data every 5 minutes
+    const unsigned long SENSOR_INTERVAL = 2000;  
+    const unsigned long SEND_INTERVAL = 300000;  
 }
 
-// Utility functions for validation and debugging
 namespace CalibrationUtils {
     bool validateSoilMoistureReading(int rawValue);
     bool validateWaterLevelReading(int rawValue);

--- a/iot-devices/include/utils/SensorCalibration.h
+++ b/iot-devices/include/utils/SensorCalibration.h
@@ -51,7 +51,7 @@ namespace WaterLevelCalibration {
 
 // Relay Control Thresholds
 namespace RelayThresholds {
-    const int SOIL_MOISTURE_THRESHOLD = 20;   // 0-20% soil moisture triggers pump
+    const int SOIL_MOISTURE_THRESHOLD = 10;   // 0-10% soil moisture triggers pump
     
 }
 

--- a/iot-devices/include/utils/SensorCalibration.h
+++ b/iot-devices/include/utils/SensorCalibration.h
@@ -9,6 +9,7 @@ namespace Pins {
     const int SOIL_MOISTURE_PIN = 35;  // GPIO35 (ADC1 - safe with WiFi)
     const int SOIL_TEMP_PIN = 4;      // GPIO4 for DS18B20 soil temperature sensor
     const int RELAY_PIN = 17;          // GPIO17 for relay control
+    const int MODEM_RELAY_PIN = 23;    // GPIO23 for modem power relay
     const int RAIN_SENSOR_PIN = 18;    // GPIO18 for digital rain detection
     const int WATER_LEVEL_PIN = 34;    // GPIO34 for water level sensor (analog - ADC capable)
     const int SDA_PIN = 21;            // SDA pin for OLED
@@ -51,7 +52,7 @@ namespace WaterLevelCalibration {
 // Relay Control Thresholds
 namespace RelayThresholds {
     const int SOIL_MOISTURE_THRESHOLD = 20;   // 0-20% soil moisture triggers pump
-    // Removed temperature threshold since we only use soil moisture now
+    
 }
 
 // Timing Configuration

--- a/iot-devices/src/actuators/ModemRelay.cpp
+++ b/iot-devices/src/actuators/ModemRelay.cpp
@@ -1,0 +1,24 @@
+#include "actuators/ModemRelay.h"
+
+ModemRelay::ModemRelay(int relayPin) : pin(relayPin), isActive(false) {
+}
+
+void ModemRelay::begin() {
+    pinMode(pin, OUTPUT);
+    turnOn();  
+    Serial.printf("Modem relay initialized on GPIO%d and activated\n", pin);
+}
+
+void ModemRelay::turnOn() {
+    isActive = true;
+    digitalWrite(pin, LOW);  
+}
+
+void ModemRelay::turnOff() {
+    isActive = false;
+    digitalWrite(pin, HIGH);  
+}
+
+bool ModemRelay::isRelayActive() const {
+    return isActive;
+}

--- a/iot-devices/src/main.cpp
+++ b/iot-devices/src/main.cpp
@@ -43,7 +43,7 @@ void setup() {
     delay(1000);
     
     modemRelay.begin();  
-    delay(2000);  /
+    delay(2000);
     
     Serial.println("=== Smart Irrigation System with MQTT ===");
     
@@ -192,9 +192,9 @@ void controlPump() {
 
 void updateDisplay() {
     oled.updateSensorData(dht11.getTemperature(), dht11.getHumidity(),
-                         soilSensor.getPercentage(), waterSensor.getStatus(),
-                         rainSensor.isRainDetected(), relay.isRelayActive(),
-                         mqttClient.isConnected()); 
+                         soilSensor.getPercentage(), soilTempSensor.getTemperature(),
+                         waterSensor.getStatus(), rainSensor.isRainDetected(), 
+                         relay.isRelayActive(), mqttClient.isConnected()); 
 }
 
 void sendDataToMQTT() {  

--- a/iot-devices/src/main.cpp
+++ b/iot-devices/src/main.cpp
@@ -7,6 +7,7 @@
 #include "sensors/RainSensor.h"
 #include "sensors/WaterLevelSensor.h"
 #include "actuators/RelayController.h"
+#include "actuators/ModemRelay.h"
 #include "display/OLEDDisplay.h"
 #include "network/MQTTClient.h"
 
@@ -22,6 +23,7 @@ SoilTemperatureSensor soilTempSensor(Pins::SOIL_TEMP_PIN);
 RainSensor rainSensor(Pins::RAIN_SENSOR_PIN);
 WaterLevelSensor waterSensor(Pins::WATER_LEVEL_PIN);
 RelayController relay(Pins::RELAY_PIN);
+ModemRelay modemRelay(Pins::MODEM_RELAY_PIN);
 OLEDDisplay oled(Pins::SDA_PIN, Pins::SCL_PIN);
 
 MQTTClient mqttClient(MQTT_SERVER, MQTT_PORT, MQTT_USERNAME, MQTT_PASSWORD, 
@@ -39,6 +41,9 @@ bool sensorDataValid = false;
 void setup() {
     Serial.begin(115200);
     delay(1000);
+    
+    modemRelay.begin();  
+    delay(2000);  /
     
     Serial.println("=== Smart Irrigation System with MQTT ===");
     
@@ -105,8 +110,8 @@ void initializeComponents() {
     
     Serial.printf("DHT11 on GPIO%d, Soil moisture on GPIO%d, Relay on GPIO%d\n", 
                   Pins::DHT11_PIN, Pins::SOIL_MOISTURE_PIN, Pins::RELAY_PIN);
-    Serial.printf("Rain sensor on GPIO%d, Water level on GPIO%d\n", 
-                  Pins::RAIN_SENSOR_PIN, Pins::WATER_LEVEL_PIN);
+    Serial.printf("Rain sensor on GPIO%d, Water level on GPIO%d, Modem relay on GPIO%d\n", 
+                  Pins::RAIN_SENSOR_PIN, Pins::WATER_LEVEL_PIN, Pins::MODEM_RELAY_PIN);
     Serial.printf("OLED on SDA%d/SCL%d\n", Pins::SDA_PIN, Pins::SCL_PIN);
 }
 


### PR DESCRIPTION
This pull request introduces support for controlling a modem relay in the smart irrigation system and refines the display and pump control logic. The main changes include adding a new `ModemRelay` actuator, updating soil moisture thresholds for pump activation, and improving the OLED display to show more sensor data. These updates enhance hardware control and provide clearer, more relevant information on the device display.

### Hardware Support

* Added new `ModemRelay` actuator class (`ModemRelay.h`/`ModemRelay.cpp`) and integrated it into the system initialization and logging, including assignment to GPIO23 and activation during setup. [[1]](diffhunk://#diff-a43b9cce554ae14934c4ee5db118774a953e3512da002408109b046020426363R1-R19) [[2]](diffhunk://#diff-0d4c68e75a645da6393e5fddca64ba8f67dd0ac61d417467bdd5d9f472d7e3f4R1-R24) [[3]](diffhunk://#diff-cae523fc2945603de290ac4fd0408f6c26fbfd55e3af530a9f735c519f134025R12) [[4]](diffhunk://#diff-6a2ad92a054021222139fef8fe46ef3fe1408cbc9ba736b4c8eb72ad3456ca0cR10) [[5]](diffhunk://#diff-6a2ad92a054021222139fef8fe46ef3fe1408cbc9ba736b4c8eb72ad3456ca0cR26) [[6]](diffhunk://#diff-6a2ad92a054021222139fef8fe46ef3fe1408cbc9ba736b4c8eb72ad3456ca0cR45-R47) [[7]](diffhunk://#diff-6a2ad92a054021222139fef8fe46ef3fe1408cbc9ba736b4c8eb72ad3456ca0cL108-R114)

### Sensor Thresholds

* Lowered the soil moisture threshold for pump activation from 20% to 10% in both `RelayController` and calibration constants, making the system more sensitive to dry soil. [[1]](diffhunk://#diff-214ebb346d22fd1940e7734301666881bfb8d70ddc026b16f2578b49e60efe63L11-R11) [[2]](diffhunk://#diff-cae523fc2945603de290ac4fd0408f6c26fbfd55e3af530a9f735c519f134025L53-R55)

### Display Improvements

* Updated the OLED display code and interface to show soil temperature, reorganize displayed sensor data, and clarify status information (including pump, rain, water level, and WiFi). The display update method now accepts soil temperature as an argument. [[1]](diffhunk://#diff-f281e667183be499487422abd9ae2bde9d7f46b06a85c2b4bde1172c004b387bL23-R23) [[2]](diffhunk://#diff-2a08ffbb48151601d3321ffd363f7a8fb889982ce3b944b6ef5bd94610062377L91-L157) [[3]](diffhunk://#diff-6a2ad92a054021222139fef8fe46ef3fe1408cbc9ba736b4c8eb72ad3456ca0cL190-R197)

### Codebase Cleanup

* Removed redundant comments and improved clarity in OLED initialization and display code, making the codebase easier to maintain. [[1]](diffhunk://#diff-2a08ffbb48151601d3321ffd363f7a8fb889982ce3b944b6ef5bd94610062377L17-L21) [[2]](diffhunk://#diff-2a08ffbb48151601d3321ffd363f7a8fb889982ce3b944b6ef5bd94610062377L35-R33) [[3]](diffhunk://#diff-2a08ffbb48151601d3321ffd363f7a8fb889982ce3b944b6ef5bd94610062377L63) [[4]](diffhunk://#diff-2a08ffbb48151601d3321ffd363f7a8fb889982ce3b944b6ef5bd94610062377L72-L75) [[5]](diffhunk://#diff-2a08ffbb48151601d3321ffd363f7a8fb889982ce3b944b6ef5bd94610062377L91-L157)